### PR TITLE
Fix ability radial menu unexpectedly grabbing focus

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -22,11 +22,11 @@
  * For more details, see https://docs.gradle.org/7.6/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    // not necessary but usefull to test stuff with the "mantle of the raven"
+    // not necessary but useful to test stuff with the "mantle of the raven"
     // downside is it adds like 10 mods including gregtech
-    // runtimeOnly("com.github.GTNewHorizons:WitchingGadgets:1.5.12-GTNH:dev")
+    // runtimeOnly("com.github.GTNewHorizons:WitchingGadgets:1.5.17-GTNH:dev")
 
-    runtimeOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.31-GTNH:dev")
+    runtimeOnly("com.github.GTNewHorizons:NotEnoughItems:2.6.46-GTNH:dev")
     implementation("com.github.GTNewHorizons:Botania:1.11.5-GTNH:dev")
     implementation("com.github.GTNewHorizons:Baubles:1.0.4:dev")
     implementation("curse.maven:travellers-gear-224440:2262113")

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.26'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.29'
 }
 
 

--- a/src/main/java/com/gtnewhorizons/travellersgearneo/mixins/late/MixinKeyHandler.java
+++ b/src/main/java/com/gtnewhorizons/travellersgearneo/mixins/late/MixinKeyHandler.java
@@ -10,6 +10,7 @@ import org.lwjgl.input.Keyboard;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -47,24 +48,27 @@ public class MixinKeyHandler {
     @Shadow(remap = false)
     public static KeyBinding activeAbilitiesWheel;
 
-    private static final KeyBinding activeAbility1 = new KeyBinding(
+    @Unique
+    private static final KeyBinding travellersGearNeo$activeAbility1 = new KeyBinding(
             "TG.keybind.activeAbility1",
             Keyboard.KEY_NONE,
             TravellersGear.MODNAME);
-    private static final KeyBinding activeAbility2 = new KeyBinding(
+    @Unique
+    private static final KeyBinding travellersGearNeo$activeAbility2 = new KeyBinding(
             "TG.keybind.activeAbility2",
             Keyboard.KEY_NONE,
             TravellersGear.MODNAME);
-    private static final KeyBinding activeAbility3 = new KeyBinding(
+    @Unique
+    private static final KeyBinding travellersGearNeo$activeAbility3 = new KeyBinding(
             "TG.keybind.activeAbility3",
             Keyboard.KEY_NONE,
             TravellersGear.MODNAME);
 
     @Inject(method = "<init>", at = @At("TAIL"), remap = false)
     private void travellersgearneo$registerKeys(CallbackInfo ci) {
-        ClientRegistry.registerKeyBinding(activeAbility1);
-        ClientRegistry.registerKeyBinding(activeAbility2);
-        ClientRegistry.registerKeyBinding(activeAbility3);
+        ClientRegistry.registerKeyBinding(travellersGearNeo$activeAbility1);
+        ClientRegistry.registerKeyBinding(travellersGearNeo$activeAbility2);
+        ClientRegistry.registerKeyBinding(travellersGearNeo$activeAbility3);
     }
 
     /**
@@ -90,38 +94,34 @@ public class MixinKeyHandler {
     private void handleInput() {
         if (openInventory.isPressed()) {
             EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-            if (player == null) {
-                return;
-            }
+            if (player == null) return;
+
             boolean[] hidden = new boolean[CustomizeableGuiHandler.moveableInvElements.size()];
             for (int bme = 0; bme < hidden.length; ++bme) {
                 hidden[bme] = CustomizeableGuiHandler.moveableInvElements.get(bme).hideElement;
             }
             TravellersGear.packetHandler.sendToServer(new MessageSlotSync(player, hidden));
             TravellersGear.packetHandler.sendToServer(new MessageOpenGui(player, 0));
-        } else if (activeAbility1.isPressed()) {
+        } else if (travellersGearNeo$activeAbility1.isPressed()) {
             checkAbilityKey(0);
-        } else if (activeAbility2.isPressed()) {
+        } else if (travellersGearNeo$activeAbility2.isPressed()) {
             checkAbilityKey(1);
-        } else if (activeAbility3.isPressed()) {
+        } else if (travellersGearNeo$activeAbility3.isPressed()) {
             checkAbilityKey(2);
         }
     }
 
     private void checkAbilityKey(int i) {
         EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-        if (player == null) {
-            return;
-        }
+        if (player == null) return;
+
         final Object[][] gear = ActiveAbilityHandler.instance.buildActiveAbilityList(player);
-        if (gear.length > 0) {
-            for (Object[] ability : gear) {
-                ItemStack stack = (ItemStack) ability[0];
-                if (stack != null && ClientProxyHook.keyBindingsValues[i]
-                        .equals(Item.itemRegistry.getNameForObject(stack.getItem()))) {
-                    TravellersGear.packetHandler.sendToServer(new MessageActiveAbility(player, (Integer) ability[1]));
-                    PacketActiveAbility.performAbility(player, (Integer) ability[1]);
-                }
+        for (Object[] ability : gear) {
+            ItemStack stack = (ItemStack) ability[0];
+            if (stack != null && ClientProxyHook.keyBindingsValues[i]
+                    .equals(Item.itemRegistry.getNameForObject(stack.getItem()))) {
+                TravellersGear.packetHandler.sendToServer(new MessageActiveAbility(player, (Integer) ability[1]));
+                PacketActiveAbility.performAbility(player, (Integer) ability[1]);
             }
         }
     }
@@ -132,7 +132,7 @@ public class MixinKeyHandler {
         if (event.phase != TickEvent.Phase.END) return;
 
         if (Minecraft.getMinecraft().inGameHasFocus) {
-            if (abilityLock == false) {
+            if (!abilityLock) {
                 if (activeAbilitiesWheel.getIsKeyPressed()) {
                     openAbilityWheel();
                 } else {

--- a/src/main/java/com/gtnewhorizons/travellersgearneo/mixins/late/MixinKeyHandler.java
+++ b/src/main/java/com/gtnewhorizons/travellersgearneo/mixins/late/MixinKeyHandler.java
@@ -47,12 +47,6 @@ public class MixinKeyHandler {
     @Shadow(remap = false)
     public static KeyBinding activeAbilitiesWheel;
 
-    @Shadow(remap = false)
-    public boolean[] keyDown;
-
-    private boolean lastClosing;
-    private boolean lastOpening;
-
     private static final KeyBinding activeAbility1 = new KeyBinding(
             "TG.keybind.activeAbility1",
             Keyboard.KEY_NONE,
@@ -66,7 +60,7 @@ public class MixinKeyHandler {
             Keyboard.KEY_NONE,
             TravellersGear.MODNAME);
 
-    @Inject(method = "<init>", at = @At("TAIL"))
+    @Inject(method = "<init>", at = @At("TAIL"), remap = false)
     private void travellersgearneo$registerKeys(CallbackInfo ci) {
         ClientRegistry.registerKeyBinding(activeAbility1);
         ClientRegistry.registerKeyBinding(activeAbility2);
@@ -140,28 +134,9 @@ public class MixinKeyHandler {
         if (Minecraft.getMinecraft().inGameHasFocus) {
             if (abilityLock == false) {
                 if (activeAbilitiesWheel.getIsKeyPressed()) {
-                    if (!lastClosing) {
-                        openAbilityWheel();
-                        lastOpening = true;
-                        lastClosing = false;
-                    }
+                    openAbilityWheel();
                 } else {
                     closeAbilityWheel();
-                    lastOpening = false;
-                    lastClosing = false;
-                }
-            }
-        } else {
-            if (abilityLock == true) {
-                if (activeAbilitiesWheel.getIsKeyPressed()) {
-                    if (!lastOpening) {
-                        abilityLock = false;
-                        lastOpening = false;
-                        lastClosing = true;
-                    }
-                } else {
-                    lastOpening = false;
-                    lastClosing = false;
                 }
             }
         }

--- a/src/main/java/com/gtnewhorizons/travellersgearneo/mixins/late/MixinTGClientCommand.java
+++ b/src/main/java/com/gtnewhorizons/travellersgearneo/mixins/late/MixinTGClientCommand.java
@@ -30,27 +30,28 @@ public class MixinTGClientCommand {
             EntityPlayer player = (EntityPlayer) sender;
             if (args.length == 1) {
                 player.addChatMessage(
-                        new ChatComponentText(EnumChatFormatting.RED + "Usage: travellersgear bind {1,2,3}"));
+                        new ChatComponentText(EnumChatFormatting.RED + "Usage: /travellersgear bind {1,2,3}"));
                 return;
             }
             int key = MathHelper.parseIntWithDefault(args[1], 0);
             if (key < 1 || key > 3) {
                 player.addChatMessage(
-                        new ChatComponentText(EnumChatFormatting.RED + "Usage: travellersgear bind {1,2,3}"));
+                        new ChatComponentText(EnumChatFormatting.RED + "Usage: /travellersgear bind {1,2,3}"));
                 return;
             }
             ItemStack stack = player.getHeldItem();
             if (stack == null) {
                 player.addChatMessage(
                         new ChatComponentText(
-                                EnumChatFormatting.RED + "You need to hold in your hand item you want to bind!"));
+                                EnumChatFormatting.RED
+                                        + "You need to be holding the item you want to bind in your hand!"));
                 return;
             }
             if (stack.getItem() instanceof IActiveAbility) {
                 String itemName = Item.itemRegistry.getNameForObject(stack.getItem());
                 player.addChatMessage(
                         new ChatComponentText(
-                                EnumChatFormatting.GREEN + "Successfully binded " + itemName + " to key " + key));
+                                EnumChatFormatting.GREEN + "Successfully bound " + itemName + " to key " + key));
                 ClientProxyHook.bindKey(key - 1, itemName);
             } else {
                 player.addChatMessage(


### PR DESCRIPTION
When the ability radial menu was bound to a keyboard key, it was challenging to select an ability as the menu would grab the mouse cursor again immediately after opening. This did not affect bindings to mouse buttons.

Couldn't prevent myself from including some simple refactorings as the code wasn't great. This is all in a separate commit. I can drop it in case there are concerns with it in regard to our current dev freeze.

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17347